### PR TITLE
[miraikan_demo] イベント用のプログラム追加

### DIFF
--- a/facial_expression/miraikan_demo/euslisp/lecture-demo.l
+++ b/facial_expression/miraikan_demo/euslisp/lecture-demo.l
@@ -51,6 +51,7 @@
       (send *ri* :disable-life))
   (send *ri* :servo-on)
   (send *ri* :set-language "Japanese")
+  (send *ri* :speak "\\vct=130\\ヨイショ")
   (send *ri* :set-master-volume 50) ;; with mic
   (send *ri* :stop-grasp)
   ;;(send *ri* :set-basic-awareness-enabled nil)

--- a/facial_expression/miraikan_demo/euslisp/lecture-demo.l
+++ b/facial_expression/miraikan_demo/euslisp/lecture-demo.l
@@ -1,0 +1,126 @@
+#!/usr/bin/env roseus
+
+;; load package
+(ros::load-ros-package "peppereus")
+(ros::load-ros-package "sensor_msgs")
+(ros::load-ros-package "std_srvs")
+
+;; load files
+(require :pepper-interface "package://peppereus/pepper-interface.l")
+
+;; var
+(defvar *process-rate* 5)
+
+;; parameter
+(defparameter *continue* t)
+
+(ros::roseus "lecture-demo")
+
+(ros::subscribe "joy" sensor_msgs::Joy
+		#'(lambda (msg)
+		    (let (button)
+		      ;; reset value
+		      (setq *continue* t)
+		      ;; update value
+		      (setq button (send msg :buttons))
+
+		      ;; A button: deai_1
+		      (if (eq (elt button 0) 1)
+			  (progn
+			    (ros::wait-for-service "deai_1")
+                            (call-empty-service "deai_1")
+			    ))
+
+		      ;; B button: deai_2
+		      (if (eq (elt button 1) 1)
+			  (progn
+			    (ros::wait-for-service "deai_2")
+                            (call-empty-service "deai_2")
+			    ))
+		      
+		      ;; Logicool button: stop this node
+		      (if (eq (elt button 8) 1)
+			  (setq *continue* nil))
+		      )))
+		      
+(defun init ()
+  (unless (boundp '*ri*)
+    (pepper-init))
+  ;; check pepper's life
+  (if (not (string= (send *ri* :get-life) "disabled"))
+      (send *ri* :disable-life))
+  (send *ri* :servo-on)
+  (send *ri* :set-language "Japanese")
+  (send *ri* :set-master-volume 50) ;; with mic
+  (send *ri* :stop-grasp)
+  ;;(send *ri* :set-basic-awareness-enabled nil)
+  ;;(send *ri* :set-background-movement-enabled nil)
+  )
+
+(defun main ()
+  (ros::rate *process-rate*)
+  (init)
+  (print "start")
+  (let ((tm nil)
+	(tm2 nil))
+    (while *continue*
+      (if (not tm)
+      	  (setq tm (ros::time-now)))
+      (if (not tm2)
+      	  (setq tm2 (ros::time-now)))
+      ;;(print (send (ros::time- (ros::time-now) tm) :to-sec))
+      (if (and tm
+      	       (> (send (ros::time- (ros::time-now) tm) :to-sec) 10))
+      	  (progn
+      	    (send *ri* :angle-vector-sequence (list #f(2.0 -2.0 -5.0 85.0 10.0 -70.0 -20.0 -40.0 85.0 -10.0 70.0 20.0 40.0 0.0 0.0) #f(2.0 -2.0 -5.0 85.0 20.0 -70.0 -20.0 -40.0 85.0 -20.0 70.0 20.0 40.0 0.0 -10.0) #f(2.0 -2.0 -5.0 85.0 10.0 -70.0 -20.0 -40.0 85.0 -10.0 70.0 20.0 40.0 0.0 0.0)) (list 1000 1000 1000))
+      	    (setq tm nil)
+      	    ))
+      (if (and tm2
+      	       (> (send (ros::time- (ros::time-now) tm2) :to-sec) 35))
+      	  (progn
+      	    (send *pepper* :head :neck-y :joint-angle -40)
+      	    (send *pepper* :head :neck-p :joint-angle 10)
+      	    (send *ri* :angle-vector (send *pepper* :angle-vector) 800)
+      	    (send *ri* :wait-interpolation)
+	    
+      	    (send *pepper* :head :neck-p :joint-angle -10)
+      	    (send *ri* :angle-vector (send *pepper* :angle-vector) 800)
+      	    (send *ri* :wait-interpolation)
+	    
+      	    ;; (send *pepper* :head :neck-p :joint-angle 10)
+      	    ;; (send *ri* :angle-vector (send *pepper* :angle-vector) 800)
+      	    ;; (send *ri* :wait-interpolation)
+	    
+      	    ;; (send *pepper* :head :neck-p :joint-angle -10)
+      	    ;; (send *ri* :angle-vector (send *pepper* :angle-vector) 800)
+      	    ;; (send *ri* :wait-interpolation)
+
+      	    (send *pepper* :head :neck-p :joint-angle 10)
+      	    (send *ri* :angle-vector (send *pepper* :angle-vector) 800)
+      	    (send *ri* :wait-interpolation)
+	    
+      	    (send *pepper* :head :neck-p :joint-angle 0)
+      	    (send *ri* :angle-vector (send *pepper* :angle-vector) 800)
+      	    (send *ri* :wait-interpolation)
+	    
+      	    (send *pepper* :reset-pose)
+      	    (send *ri* :angle-vector (send *pepper* :angle-vector) 800)
+      	    (send *ri* :wait-interpolation)
+      	    (setq tm2 nil)
+      	    ))
+      (ros::spin-once)
+      ;; (send *ri* :spin-once)
+      (ros::sleep)
+      ); while
+    )
+
+  (send *ri* :speak "おしまい")
+  (send *ri* :hide-image)
+  (send *ri* :set-language "English")
+  (print "end")
+  )
+
+
+
+
+

--- a/facial_expression/miraikan_demo/euslisp/robot-behavior-server.l
+++ b/facial_expression/miraikan_demo/euslisp/robot-behavior-server.l
@@ -1,0 +1,52 @@
+(ros::roseus "miraikan")
+
+(ros::load-ros-package "std_msgs")
+;; (ros::roseus-add-msgs "miraikan_demo")
+(ros::load-ros-package "miraikan_demo")
+(setq *mode-srv* "/demo_mode")
+
+(defun call_demo (mode time_delay)
+  (let* ((req (instance miraikan_demo::ModeRequest :init
+			:mode mode :time_delay time_delay))
+	 res)
+    (format t "waiting service ...~%")
+    (ros::wait-for-service *mode-srv*)
+    (setq res (ros::service-call *mode-srv* req))
+    (format t "called service~%")
+    )
+  )
+
+(defun episode_deai_1 (req)
+  (let ((m (send req :response)))
+    (call_demo 0 4)  ;; こちさんと出会ってからもう8年経ったね
+    m)
+  )
+
+(defun episode_deai_2 (req)
+  (let ((m (send req :response)))
+    (call_demo 1 10)  ;; 皆に振り向いてもらえなくて悲しかったよ
+    (ros::duration-sleep 2.0)
+    (call_demo 2 7)  ;; こちさんが見つけてくれたね
+    m)
+  )
+
+;; funcs -> rossrv msg
+(ros::load-ros-package "std_srvs")
+(defvar *process-rate* 5)
+
+(ros::advertise-service "deai_1" std_srvs::Empty #'episode_deai_1)
+(ros::advertise-service "deai_2" std_srvs::Empty #'episode_deai_2)
+
+(defun main ()
+  (ros::rate *process-rate*)
+  (format t "robot behavior server start~%")
+  (while (ros::ok)
+    (ros::spin-once)
+    (ros::sleep)
+    )
+  (format t "robot behavior server end~%")
+  )
+
+;; (main)
+;; (ros::exit)
+

--- a/facial_expression/miraikan_demo/launch/lecture-demo.launch
+++ b/facial_expression/miraikan_demo/launch/lecture-demo.launch
@@ -1,0 +1,40 @@
+<launch>
+<arg name="network_interface"   default="enp0s31f6" />
+<arg name="launch_joy" default="false" />
+<arg name="eyebrows_server_ip" default="localhost" />
+<arg name="run_eyebrows_server" default="false" />
+<arg name="use_robot" default="true" />
+
+<include file="$(find jsk_pepper_startup)/launch/jsk_pepper_startup.launch" >
+  <arg name="network_interface"   value="$(arg network_interface)" />
+  <arg name="launch_joy" default="false" />
+  <arg name="launch_dashboard" default="false" />
+</include>
+  
+<node pkg="joy" type="joy_node" name="joy_node" respawn="true" >
+  <param name="dev" value="/dev/input/js0" />
+  <param name="deadzone" value="0.3" />
+  <param name="autorepeat_rate" value="20" />
+</node>
+
+<!-- kochigami-develop -->
+<include file="$(find naoqi_apps)/launch/basic_awareness.launch" />
+
+<!-- kochigami-develop -->
+<include file="$(find naoqi_apps)/launch/background_movement.launch" />
+
+<!-- kochigami-develop -->
+<include file="$(find naoqi_apps)/launch/tablet.launch" />
+
+<node name="robot_behavior_server"
+      pkg="roseus" type="roseus"
+      args="$(find miraikan_demo)/euslisp/robot-behavior-server.l &quot;(progn (main))&quot;" output="screen" respawn="true" />
+
+<!-- requires source ~/miraikan_ws/devel/setup.bash -->
+<include file="$(find miraikan_demo)/launch/demo.launch">
+  <arg name="eyebrows_server_ip" value="$(arg eyebrows_server_ip)"/>
+  <arg name="run_eyebrows_server" value="$(arg run_eyebrows_server)" />
+  <arg name="use_robot" value="$(arg use_robot)" />
+</include>
+
+</launch>

--- a/facial_expression/miraikan_demo/launch/lecture-demo.launch
+++ b/facial_expression/miraikan_demo/launch/lecture-demo.launch
@@ -30,6 +30,10 @@
       pkg="roseus" type="roseus"
       args="$(find miraikan_demo)/euslisp/robot-behavior-server.l &quot;(progn (main))&quot;" output="screen" respawn="true" />
 
+<node name="lecture_demo"
+      pkg="roseus" type="roseus"
+      args="$(find miraikan_demo)/euslisp/lecture-demo.l &quot;(progn (unix:sleep 5) (main))&quot;" output="screen" respawn="true" />
+
 <!-- requires source ~/miraikan_ws/devel/setup.bash -->
 <include file="$(find miraikan_demo)/launch/demo.launch">
   <arg name="eyebrows_server_ip" value="$(arg eyebrows_server_ip)"/>

--- a/facial_expression/miraikan_demo/scripts/motion_talk_node.py
+++ b/facial_expression/miraikan_demo/scripts/motion_talk_node.py
@@ -4,7 +4,7 @@
 import rospy
 from std_msgs.msg import Int32
 
-from motion_talk import Talk
+from talk_motion import Talk
 
 class TopicToMotion(object):
     def __init__(self):


### PR DESCRIPTION
[Pepperのイベントプログラムへの組み込み](https://github.com/MiyabiTane/Deco_with_robot/tree/main/facial_expression/miraikan_demo#pepper%E3%81%AE%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%97%E3%83%AD%E3%82%B0%E3%83%A9%E3%83%A0%E3%81%B8%E3%81%AE%E7%B5%84%E3%81%BF%E8%BE%BC%E3%81%BF) を見て、必要そうな以下のファイルを追加しました。
（既にこのパッケージに含まれていると、ファイル編集の手間が減るかな、と思ったため）

`lecture-demo.launch`をlaunch以下に、
`robot-behaior-server.l`と`lecture-demo.l`をeuslisp以下に入れました。

昨日試したファイルほぼそのままですが、まだ実機で試せていないです。後ほど試そうと思います。
