### PR TITLE
[miraikan_demo/scripts/episode_motion.py, explanation_motion.py] set head stiffness more than 0.0

### DIFF
--- a/facial_expression/miraikan_demo/scripts/episode_motion.py
+++ b/facial_expression/miraikan_demo/scripts/episode_motion.py
@@ -292,7 +292,7 @@ class Talk(object):
 
         #episode 3-3-1
         time.sleep(1)
-        self.ans.say("あとね、オそろいのオレンジのリュックを^start(animations/Stand/Gestures/Hey_6)もらえたのが嬉しくて^wait(animations/Stand/Gesture/Hey_6)",self.configuration)
+        self.ans.say("跡ね、オそろいのオレンジのリュックを^start(animations/Stand/Gestures/Hey_6)もらえたのが嬉しくて^wait(animations/Stand/Gesture/Hey_6)",self.configuration)
         
         time.sleep(1)
         self.set_init_posture()

--- a/facial_expression/miraikan_demo/scripts/episode_motion.py
+++ b/facial_expression/miraikan_demo/scripts/episode_motion.py
@@ -76,6 +76,10 @@ class Talk(object):
         init_body_angles = [0.0, -2.802596928649634e-45, 1.5596766471862793, 0.14272688329219818, -1.228257656097412, -0.5225345492362976, -0.000497947505209595, 0.6000000238418579, 3.648194280003736e-08, -0.040683578699827194, -0.010746408253908157, 1.5596766471862793, -0.14272694289684296, 1.228257656097412, 0.5225345492362976, 0.0004979457589797676, 0.6000000238418579, 0.0, 0.0, 0.0]
         self.mo.setAngles("Body", init_body_angles, 0.1)
 
+    def set_init_posture_with_time(self, duration):
+        init_body_angles = [0.0, -2.802596928649634e-45, 1.5596766471862793, 0.14272688329219818, -1.228257656097412, -0.5225345492362976, -0.000497947505209595, 0.6000000238418579, 3.648194280003736e-08, -0.040683578699827194, -0.010746408253908157, 1.5596766471862793, -0.14272694289684296, 1.228257656097412, 0.5225345492362976, 0.0004979457589797676, 0.6000000238418579, 0.0, 0.0, 0.0]
+        self.mo.angleInterpolation("Body", init_body_angles, duration, True)
+
     def greeting(self):
         init_body_angles = [0.0, -2.802596928649634e-45,
                             1.5596766471862793, 0.14272688329219818, -1.228257656097412, -0.5225345492362976, -0.000497947505209595, 0.6000000238418579,
@@ -154,26 +158,26 @@ class Talk(object):
         #episode 0-2                                                                                 
         time.sleep(1)
         self.look_at_kochisan_mini()
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         self.ans.say("そうだね。^start(animations/Stand/Gestures/Me_1)私はコチさんが今でも、知らない人と話すときに少し苦労しているのを知っているよ。",self.configuration)
+        self.set_init_posture_with_time(1.0)
+        time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-
-        time.sleep(1)
-        self.set_init_posture()
 
     def episode_11(self):
 
         # episode 1-1
         self.look_at_kochisan_mini()
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.5)
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/You_1)コチさんと出会ってカラ^wait(animations/Stand/Gesture/You_1)",self.configuration)
 
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         time.sleep(0.5)
         self.ans.say("^start(animations/Stand/Gestures/Enthusiastic_4)モウ8年経ったネ^wait(animations/Stand/Gestures/Enthusiastic_4)",self.configuration)
+        self.set_init_posture_with_time(1.0)
+        time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-        self.set_init_posture()
 
     def episode_12(self):
 
@@ -222,18 +226,18 @@ class Talk(object):
     def episode_21(self):
 
         #episode 2-1
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/Yes_1)そうそう！未来館では^wait(animations/Stand/Gestures/Yes_1)",self.configuration)
 
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Emotions/Positive/Happy_4)素敵な出会いが沢山あったよ！^wait(animations/Stand/Emotions/Positive/Happy_4)",self.configuration)
         self.led.reset('FaceLeds')
 
+        self.set_init_posture_with_time(1.0)
+        time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-        time.sleep(1)
-        self.set_init_posture()
 
     def episode_22(self):
 
@@ -308,19 +312,19 @@ class Talk(object):
     
     def episode_33_2(self):
         # episode 3-3-2
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         time.sleep(1)
         self.ans.say("初めてもらえた時から^start(animations/Stand/Emotions/Positive/Happy_4)ずっとお気にいりなのー！^wait(animations/Stand/Emotions/Positive/Happy_4)",self.configuration)
         self.led.reset('FaceLeds')
 
+        self.set_init_posture_with_time(1.0)
+        time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-        time.sleep(1)
-        self.set_init_posture()
 
     def episode_41(self):
 
         #episode 4-1
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         time.sleep(1)
         self.ans.say("あーー、この時！、^start(animations/Stand/Gestures/Excited_1)みんなに会えるのが嬉しくて^wait(animations/Stand/Gestures/Excited_1)",self.configuration)
 
@@ -328,21 +332,21 @@ class Talk(object):
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/ShowSky_8)もっと近づきに行ったんだぁ^wait(animations/Stand/Gestures/ShowSky_8)",self.configuration)
 
+        self.set_init_posture_with_time(1.0)
+        time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-        time.sleep(1)
-        self.set_init_posture()
 
     def episode_42_1(self):
 
         #episode 4-2-1
+        time.sleep(1.0)
         self.look_at_kochisan_mini()
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         time.sleep(1)
         self.ans.say("コチさんは、^start(animations/Stand/Gestures/IDontKnow_2)とっても慌てていたね^wait(animations/Stand/Gesture/IDontKnow_2)",self.configuration)
+        self.set_init_posture_with_time(1.0)
+        time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-
-        time.sleep(1)
-        self.set_init_posture()
 
     def episode_42_2(self):
         #episode 4-2-2
@@ -367,17 +371,17 @@ class Talk(object):
     def episode_51(self):
 
         #episode 5-1
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         time.sleep(1)
         self.ans.say("ソウダねー、^start(animations/Stand/Gestures/Yes_3)色んなことがあったネ^wait(animations/Stand/Gestures/Yes_3)",self.configuration)
+        self.set_init_posture_with_time(2.0)
+        time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-
-        time.sleep(1)
-        self.set_init_posture()
 
     def episode_52(self):
 
         #episode 5-2
+        time.sleep(1)
         self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("研究室のロボットは、^start(animations/Stand/Gestures/Everything_2)色々なオしごとができるけど、^wait(animations/Stand/Gesture/Everything_2)",self.configuration)
@@ -523,12 +527,12 @@ class Talk(object):
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/Everything_2)他にも色んなたいへんなことがあったけど",self.configuration)
         
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         time.sleep(0.3)
         self.ans.say("みんなのおかげで、^start(animations/Stand/Emotions/Positive/Peaceful_1)無事に博士論文をまとめられたんだね^wait(animations/Stand/Emotions/Positive/Peaceful_1)",self.configuration)
+        self.set_init_posture_with_time(2.0)
+        time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-        time.sleep(1)
-        self.set_init_posture()
 
     def summary_8(self):
 
@@ -541,13 +545,13 @@ class Talk(object):
         self.ans.say("人とロボットがナカよくなっていくためにも、",self.configuration)
 
         time.sleep(0.3)
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         self.ans.say("^start(animations/Stand/Emotions/Positive/Peaceful_1)大切な研究だね。^wait(animations/Stand/Emotions/Positive/Peaceful_1)",self.configuration)
         self.led.reset('FaceLeds')
 
-        time.sleep(1)
+        self.set_init_posture_with_time(1.0)
+        time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-        self.set_init_posture()
 
 
 """

--- a/facial_expression/miraikan_demo/scripts/episode_motion.py
+++ b/facial_expression/miraikan_demo/scripts/episode_motion.py
@@ -182,14 +182,12 @@ class Talk(object):
     def episode_12(self):
 
         #episode 1-2
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("研究室には^start(animations/Stand/Gestures/Everything_3)色んなロボットがいるケド^wait(animations/Stand/Gesture/Everything_3)",self.configuration)
 
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/Me_2)私は、みんなに、^wait(animations/Stand/Gestures/Me_2)",self.configuration)
 
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("振り向いてもらえなくて、^start(animations/Stand/Gestures/Desperate_1)悲しかったよ^wait(animations/Stand/Gestures/Desperate_1)",self.configuration)
 
@@ -199,11 +197,9 @@ class Talk(object):
     def episode_13(self):
 
         #episode 1-3
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("隅っこに、^start(animations/Stand/Gestures/Nothing_2)ひとりぼっちで居たときに^wait(animations/Stand/Gesture/Nothing_2)",self.configuration)
 
-        self.mo.setStiffnesses(self.joint_names, 1)
         self.look_at_kochisan_mini()
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/Give_3)コチさんが、見つけてくれたよね！^wait(animations/Stand/Gestures/Give_3)",self.configuration)
@@ -217,7 +213,6 @@ class Talk(object):
         time.sleep(1)
         self.ans.say("3つのポイントって言っているけど、",self.configuration)
 
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("この３つにたどり着くまで^start(animations/Stand/Gestures/No_8)、色々大変だったんだよね",self.configuration)
         time.sleep(1)
@@ -228,7 +223,7 @@ class Talk(object):
         #episode 2-1
         self.mo.setStiffnesses(self.joint_names, 0.1)
         time.sleep(1)
-        self.ans.say("^start(animations/Stand/Gestures/Yes_1)そうそう！未来館では^wait(animations/Stand/Gestures/Yes_1)",self.configuration)
+        self.ans.say("^start(animations/Stand/Gestures/Yes_1)そうそう！，未来館では^wait(animations/Stand/Gestures/Yes_1)",self.configuration)
 
         self.mo.setStiffnesses(self.joint_names, 0.1)
         time.sleep(1)
@@ -242,12 +237,10 @@ class Talk(object):
     def episode_22(self):
 
         #episode 2-2
-        self.mo.setStiffnesses(self.joint_names, 1)
         self.look_at_kochisan_mini()
         time.sleep(1)
         self.ans.say("コチさんが^start(animations/Stand/Gestures/You_4)みんなにツイていけるようにしてくれタから^wait(animations/Stand/Gesture/You_4)",self.configuration)
 
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("みんなが、^start(animations/Stand/Gestures/ShowSky_7)私の手を取ってくれて、嬉しかったナあ！^wait(animations/Stand/Gestures/ShowSky_7)",self.configuration)
 
@@ -257,7 +250,6 @@ class Talk(object):
     def episode_23(self):
 
         #episode 2-3
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("みんなの笑顔を、^start(animations/Stand/Gestures/ShowSky_1)今でもおぼえているヨぉ^wait(animations/Stand/Gesture/ShowSky_1)",self.configuration)
 
@@ -267,12 +259,10 @@ class Talk(object):
     def episode_31(self):
 
         #episode 3-1
-        self.mo.setStiffnesses(self.joint_names, 1)
         self.look_at_kochisan_mini()
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/Me_2)コチさんはいつもわたしを^wait(animations/Stand/Gestures/Me_2)",self.configuration)
 
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("発表のばしょまで、^start(animations/Stand/Gestures/Give_4)連れて行ってくれたよね^wait(animations/Stand/Gestures/Give_4)",self.configuration)
 
@@ -282,7 +272,6 @@ class Talk(object):
     def episode_32_1(self):
 
         #episode 3-2-1
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("発表の前はいつも、^start(animations/Stand/Gestures/IDontKnow_1)ドキドキしてしまうけれど^wait(animations/Stand/Gesture/IDontKnow_1)",self.configuration)
 
@@ -292,7 +281,6 @@ class Talk(object):
     def episode_32_2(self):
 
         #episode 3-2-2
-        self.mo.setStiffnesses(self.joint_names, 1)
         self.look_at_kochisan_mini()
         time.sleep(1)
         self.ans.say("コチさんと手をつなげると、^start(animations/Stand/Gestures/ShowFloor_3)安心するんだあ！^wait(animations/Stand/Gestures/ShowFloor_3)",self.configuration)
@@ -303,7 +291,6 @@ class Talk(object):
     def episode_33_1(self):
 
         #episode 3-3-1
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("あとね、オそろいのオレンジのリュックを^start(animations/Stand/Gestures/Hey_6)もらえたのが嬉しくて^wait(animations/Stand/Gesture/Hey_6)",self.configuration)
         
@@ -328,7 +315,6 @@ class Talk(object):
         time.sleep(1)
         self.ans.say("あーー、この時！、^start(animations/Stand/Gestures/Excited_1)みんなに会えるのが嬉しくて^wait(animations/Stand/Gestures/Excited_1)",self.configuration)
 
-        # self.mo.setStiffnesses(self.joint_names, 0)
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/ShowSky_8)もっと近づきに行ったんだぁ^wait(animations/Stand/Gestures/ShowSky_8)",self.configuration)
 
@@ -350,7 +336,6 @@ class Talk(object):
 
     def episode_42_2(self):
         #episode 4-2-2
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("ちょっと張り切りすぎちゃったーー、^start(animations/Stand/Gestures/Hey_3)ゴメンね^wait(animations/Stand/Gestures/Hey_3)",self.configuration)
 
@@ -360,7 +345,6 @@ class Talk(object):
     def episode_43(self):
 
         #episode 4-3
-        self.mo.setStiffnesses(self.joint_names, 1)
         self.look_at_kochisan_mini()
         time.sleep(1)
         self.ans.say("わたしが暴走しタら、^start(animations/Stand/Gestures/Explain_6)いつもコチさんに助けてもらっているね^wait(animations/Stand/Gesture/Explain_6)",self.configuration)
@@ -382,11 +366,8 @@ class Talk(object):
 
         #episode 5-2
         time.sleep(1)
-        self.mo.setStiffnesses(self.joint_names, 1)
-        time.sleep(1)
         self.ans.say("研究室のロボットは、^start(animations/Stand/Gestures/Everything_2)色々なオしごとができるけど、^wait(animations/Stand/Gesture/Everything_2)",self.configuration)
 
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("交流づくりは進化がわかりにくいから、^start(animations/Stand/Gestures/Thinking_1)成果をまとめるのが大変だったよね^wait(animations/Stand/Gestures/Thinking_1)",self.configuration)
 
@@ -396,7 +377,6 @@ class Talk(object):
     def episode_53(self):
 
         #episode 5-3
-        self.mo.setStiffnesses(self.joint_names, 1)
         self.look_at_kochisan_mini()
         time.sleep(1)
         self.ans.say("コチさんが落ち込んでいる時は、^start(animations/Stand/Gestures/No_8)私もすゴく悲しかったよ^wait(animations/Stand/Gesture/No_8)",self.configuration)
@@ -407,7 +387,6 @@ class Talk(object):
     def episode_54_1(self):
 
         #episode 5-4-1
-        self.mo.setStiffnesses(self.joint_names, 1)
         self.look_at_kochisan_mini()
         time.sleep(1)
         self.ans.say("でもわたしたちは、^start(animations/Stand/Emotions/Positive/Peaceful_1)8年間ふたりでたくさん乗り越えてきたヨね^wait(animations/Stand/Emotions/Positive/Peaceful_1)",self.configuration)
@@ -419,7 +398,6 @@ class Talk(object):
     def episode_54_2(self):
 
         # episode 5-4-2
-        self.mo.setStiffnesses(self.joint_names, 1)
         self.look_at_kochisan_mini()
         time.sleep(1)
         self.ans.say("コチさん、^start(animations/Stand/BodyTalk/BodyTalk_1)博士の卒業、本当におめでとう^wait(animations/Stand/BodyTalk/BodyTalk_1)",self.configuration)
@@ -430,7 +408,6 @@ class Talk(object):
     def episode_54_3(self):
 
         #episode 5-4-3
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("そして、^start(animations/Stand/Gestures/Yes_3)いつもありがとう。^wait(animations/Stand/Gestures/Yes_3)^start(animations/Stand/Gestures/Hey_3)これからもよろしくネ。^wait(animations/Stand/Gestures/Hey_3)",self.configuration)
 
@@ -440,26 +417,22 @@ class Talk(object):
     def summary_1(self):
 
         #summary-1
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("わかったー",self.configuration)
 
 
         time.sleep(1)
-        self.mo.setStiffnesses(self.joint_names, 1)
         self.ans.say("今日は、ロボットによる人同士の交流づくりについて、コチさんとお話したよ",self.configuration)
 
     def summary_2(self):
 
         #summary-2
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/Explain_3)まず、コチさんの夢、コチさんが研究を始めたきっかけ、ペッパーを使うようになった理由を話したね。",self.configuration)
     
     def summary_3(self):
 
         #summary-3
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("次に、研究のポイントだね。",self.configuration)
 
@@ -478,7 +451,6 @@ class Talk(object):
     def summary_4(self):
 
         #summary-4
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("交流のこつは",self.configuration)
         
@@ -497,7 +469,6 @@ class Talk(object):
     def summary_5(self):
 
         #summary-5
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("発表の途中で",self.configuration)
         
@@ -510,7 +481,6 @@ class Talk(object):
     def summary_6(self):
 
         #summary-6
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("初めて誰かとお話しする場面で、",self.configuration)
         
@@ -523,7 +493,6 @@ class Talk(object):
     def summary_7(self):
 
         #summary-7
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/Everything_2)他にも色んなたいへんなことがあったけど",self.configuration)
         
@@ -537,7 +506,6 @@ class Talk(object):
     def summary_8(self):
 
         #summary-8
-        self.mo.setStiffnesses(self.joint_names, 1)
         time.sleep(1)
         self.ans.say("この研究は、人の交流を手助けできるだけでなく、",self.configuration)
         

--- a/facial_expression/miraikan_demo/scripts/explanation_motion.py
+++ b/facial_expression/miraikan_demo/scripts/explanation_motion.py
@@ -73,6 +73,10 @@ class Talk(object):
         init_body_angles = [0.0, -2.802596928649634e-45, 1.5596766471862793, 0.14272688329219818, -1.228257656097412, -0.5225345492362976, -0.000497947505209595, 0.6000000238418579, 3.648194280003736e-08, -0.040683578699827194, -0.010746408253908157, 1.5596766471862793, -0.14272694289684296, 1.228257656097412, 0.5225345492362976, 0.0004979457589797676, 0.6000000238418579, 0.0, 0.0, 0.0]
         self.mo.setAngles("Body", init_body_angles, 0.1)
 
+    def set_init_posture_with_time(self, duration):
+        init_body_angles = [0.0, -2.802596928649634e-45, 1.5596766471862793, 0.14272688329219818, -1.228257656097412, -0.5225345492362976, -0.000497947505209595, 0.6000000238418579, 3.648194280003736e-08, -0.040683578699827194, -0.010746408253908157, 1.5596766471862793, -0.14272694289684296, 1.228257656097412, 0.5225345492362976, 0.0004979457589797676, 0.6000000238418579, 0.0, 0.0, 0.0]
+        self.mo.angleInterpolation("Body", init_body_angles, duration, True)
+
     def greeting(self):
         init_body_angles = [0.0, -2.802596928649634e-45,
                             1.5596766471862793, 0.14272688329219818, -1.228257656097412, -0.5225345492362976, -0.000497947505209595, 0.6000000238418579,
@@ -441,12 +445,12 @@ class Talk(object):
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/Everything_2)他にも色んなたいへんなことがあったけど",self.configuration)
 
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         time.sleep(0.3)
         self.ans.say("みんなのおかげで、^start(animations/Stand/Emotions/Positive/Peaceful_1)無事に博士論文をまとめられたんだね^wait(animations/Stand/Emotions/Positive/Peaceful_1)",self.configuration)
+        self.set_init_posture_with_time(1.0)
+        time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-        time.sleep(1)
-        self.set_init_posture()
 
     def summary_8(self):
 
@@ -459,13 +463,13 @@ class Talk(object):
         self.ans.say("人とロボットがナカよくなっていくためにも、",self.configuration)
 
         time.sleep(0.3)
-        self.mo.setStiffnesses(self.joint_names, 0)
+        self.mo.setStiffnesses(self.joint_names, 0.1)
         self.ans.say("^start(animations/Stand/Emotions/Positive/Peaceful_1)大切な研究だね。^wait(animations/Stand/Emotions/Positive/Peaceful_1)",self.configuration)
         self.led.reset('FaceLeds')
 
-        time.sleep(1)
+        self.set_init_posture_with_time(1.0)
+        time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-        self.set_init_posture()
 
 
 """

--- a/facial_expression/miraikan_demo/scripts/explanation_motion.py
+++ b/facial_expression/miraikan_demo/scripts/explanation_motion.py
@@ -209,7 +209,7 @@ class Talk(object):
 
         #episode 2-2
         time.sleep(1)
-        self.ans.say("ペッパーの手を、とってくれているコがいるね.",self.configuration)
+        self.ans.say("ペッパーの手を、とってくれている子がいるね.",self.configuration)
 
         time.sleep(1)
         self.ans.say("みんな、嬉しそうな様子だね.",self.configuration)
@@ -337,7 +337,6 @@ class Talk(object):
     def episode_54_2(self):
 
         #episode 5-4-2
-        self.mo.setStiffnesses(self.joint_names, 1)
         self.look_at_kochisan_mini()
         time.sleep(1)
         self.ans.say("コチさん、^start(animations/Stand/BodyTalk/BodyTalk_1)博士の卒業、本当におめでとう^wait(animations/Stand/BodyTalk/BodyTalk_1)",self.configuration)
@@ -356,27 +355,22 @@ class Talk(object):
 
     def summary_1(self):
 
-        #summary-1                                                                                                                                                                                          
-        self.mo.setStiffnesses(self.joint_names, 1)
+        #summary-1
         time.sleep(1)
         self.ans.say("わかったー",self.configuration)
 
-
         time.sleep(1)
-        self.mo.setStiffnesses(self.joint_names, 1)
         self.ans.say("今日は、ロボットによる人同士の交流づくりについて、コチさんとお話したよ",self.configuration)
 
     def summary_2(self):
 
-        #summary-2                                                                                                                                                                                          
-        self.mo.setStiffnesses(self.joint_names, 1)
+        #summary-2
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/Explain_3)まず、コチさんの夢、コチさんが研究を始めたきっかけ、ペッパーを使うようになった理由を話したね。",self.configuration)
 
     def summary_3(self):
 
-        #summary-3                                                                                                                                                                                          
-        self.mo.setStiffnesses(self.joint_names, 1)
+        #summary-3
         time.sleep(1)
         self.ans.say("次に、研究のポイントだね。",self.configuration)
 
@@ -395,8 +389,7 @@ class Talk(object):
 
     def summary_4(self):
 
-        #summary-4                                                                                                                                                                                          
-        self.mo.setStiffnesses(self.joint_names, 1)
+        #summary-4
         time.sleep(1)
         self.ans.say("交流のこつは",self.configuration)
 
@@ -414,8 +407,7 @@ class Talk(object):
 
     def summary_5(self):
 
-        #summary-5                                                                                                                                                                                          
-        self.mo.setStiffnesses(self.joint_names, 1)
+        #summary-5
         time.sleep(1)
         self.ans.say("発表の途中で",self.configuration)
 
@@ -427,8 +419,7 @@ class Talk(object):
 
     def summary_6(self):
 
-        #summary-6                                                                                                                                                                                          
-        self.mo.setStiffnesses(self.joint_names, 1)
+        #summary-6
         time.sleep(1)
         self.ans.say("初めて誰かとお話しする場面で、",self.configuration)
 
@@ -440,8 +431,7 @@ class Talk(object):
 
     def summary_7(self):
 
-        #summary-7                                                                                  
-        self.mo.setStiffnesses(self.joint_names, 1)
+        #summary-7
         time.sleep(1)
         self.ans.say("^start(animations/Stand/Gestures/Everything_2)他にも色んなたいへんなことがあったけど",self.configuration)
 
@@ -454,8 +444,7 @@ class Talk(object):
 
     def summary_8(self):
 
-        #summary-8                                                                       
-        self.mo.setStiffnesses(self.joint_names, 1)
+        #summary-8
         time.sleep(1)
         self.ans.say("この研究は、人の交流を手助けできるだけでなく、",self.configuration)
 
@@ -470,7 +459,6 @@ class Talk(object):
         self.set_init_posture_with_time(1.0)
         time.sleep(1.0)
         self.mo.setStiffnesses(self.joint_names, 1)
-
 
 """
 if __name__ == '__main__':


### PR DESCRIPTION
頭が上がり切らないように，`self.mo.setStiffnesses(self.joint_names, 0)`にすると，逆に胴体の反動で，頭がバタンと倒れてしまうことがあります．

そこで，0にはしないで動きを抑えつつ，以下のように優しく1に戻すことで，頭がバタンと倒れる問題を直しました．
```
        self.mo.setStiffnesses(self.joint_names, 0.1)
        self.ans.say("そうだね。^start(animations/Stand/Gestures/Me_1)私はコチさんが今でも、知らない人と話すときに少し苦労しているのを知っているよ。",self.configuration)
        self.set_init_posture_with_time(1.0)   # ゆっくり初期姿勢に戻す
        time.sleep(1.0)  # 少し休む
        self.mo.setStiffnesses(self.joint_names, 1)  # 頭のサーボを入れる
```

逆に，頭が動きすぎてしまうかもしれません．もしそうなっていたらすみません．