### PR TITLE
[miraikan_demo/scripts] add disable_life.py, change_volume.py

### DIFF
--- a/facial_expression/miraikan_demo/scripts/change_volume.py
+++ b/facial_expression/miraikan_demo/scripts/change_volume.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import qi
+import argparse
+import sys
+
+
+def main(session):
+
+    ad = session.service("ALAudioDevice")
+    tts = session.service("ALTextToSpeech")
+
+    # modify volume value to change volume
+    volume = 40
+    ad.setOutputVolume(volume)
+    tts.setLanguage("Japanese")
+    # Say Emile in english
+    tts.say("聞こえますか？")
+
+    print(ad.getOutputVolume())
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ip", type=str, default="127.0.0.1",
+                        help="Robot IP address. On robot or Local Naoqi: use '127.0.0.1'.")
+    parser.add_argument("--port", type=int, default=9559,
+                        help="Naoqi port number")
+    
+    args = parser.parse_args()
+    session = qi.Session()
+    try:
+        session.connect("tcp://" + args.ip + ":" + str(args.port))
+    except RuntimeError:
+        print ("Can't connect to Naoqi at ip \"" + args.ip + "\" on port " + str(args.port) +".\n"
+               "Please check your script arguments. Run with -h option for help.")
+        sys.exit(1)
+    main(session)

--- a/facial_expression/miraikan_demo/scripts/change_volume.py
+++ b/facial_expression/miraikan_demo/scripts/change_volume.py
@@ -1,22 +1,25 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+'''
+Usage:
+python change_volume.py --ip <Pepper's IP> --vol 35
+'''
+
 import qi
 import argparse
 import sys
 
 
-def main(session):
+def main(session, volume):
 
     ad = session.service("ALAudioDevice")
     tts = session.service("ALTextToSpeech")
 
-    # modify volume value to change volume
-    volume = 40
     ad.setOutputVolume(volume)
     tts.setLanguage("Japanese")
-    # Say Emile in english
-    tts.say("聞こえますか？")
+    s = ad.getOutputVolume() + "に設定しましたッ\\pau=1000\\聞こえますか？"
+    tts.say(s)
 
     print(ad.getOutputVolume())
 
@@ -24,6 +27,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--ip", type=str, default="127.0.0.1",
                         help="Robot IP address. On robot or Local Naoqi: use '127.0.0.1'.")
+    parser.add_argument("--vol", type=int, default=9559,
+                        help="Volume")
     parser.add_argument("--port", type=int, default=9559,
                         help="Naoqi port number")
     
@@ -35,4 +40,4 @@ if __name__ == "__main__":
         print ("Can't connect to Naoqi at ip \"" + args.ip + "\" on port " + str(args.port) +".\n"
                "Please check your script arguments. Run with -h option for help.")
         sys.exit(1)
-    main(session)
+    main(session, args.vol)

--- a/facial_expression/miraikan_demo/scripts/change_volume.py
+++ b/facial_expression/miraikan_demo/scripts/change_volume.py
@@ -18,7 +18,7 @@ def main(session, volume):
 
     ad.setOutputVolume(volume)
     tts.setLanguage("Japanese")
-    s = ad.getOutputVolume() + "に設定しましたッ\\pau=1000\\聞こえますか？"
+    s = str(ad.getOutputVolume()) + "に設定しましたッ\\pau=1000\\聞こえますか？"
     tts.say(s)
 
     print(ad.getOutputVolume())

--- a/facial_expression/miraikan_demo/scripts/disable_life.py
+++ b/facial_expression/miraikan_demo/scripts/disable_life.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import qi
+import argparse
+import sys
+
+def main(session):
+
+    alife = session.service("ALAutonomousLife")
+    mo = session.service("ALMotion")
+
+    alife.setState("disabled")
+    mo.wakeUp()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ip", type=str, default="127.0.0.1",
+                        help="Robot IP address. On robot or Local Naoqi: use '127.0.0.1'.")
+    parser.add_argument("--port", type=int, default=9559,
+                        help="Naoqi port number")
+    
+    args = parser.parse_args()
+    session = qi.Session()
+    try:
+        session.connect("tcp://" + args.ip + ":" + str(args.port))
+    except RuntimeError:
+        print ("Can't connect to Naoqi at ip \"" + args.ip + "\" on port " + str(args.port) +".\n"
+               "Please check your script arguments. Run with -h option for help.")
+        sys.exit(1)
+    main(session)


### PR DESCRIPTION
音量調整，AutonomousLifeをdisableする設定は、現状Choregrapheで行うと聞いたので、
念の為、Choregrapheがなくても設定できるよう、Pythonの別プログラムを用意しました．

`python disable_life.py --ip <PepperのIP>`でAutonomousLifeがオフ，サーボオンになります．

プログラムの中の音量を書き換えて，
`python change_volume.py --ip <PepperのIP>`で音量がかわります．

