### PR TITLE
[miraikan_demo] add rest, wakeup scripts

### DIFF
--- a/facial_expression/miraikan_demo/scripts/rest.py
+++ b/facial_expression/miraikan_demo/scripts/rest.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import qi
+import argparse
+import sys
+
+def main(session):
+
+    mo = session.service("ALMotion")
+    mo.rest()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ip", type=str, default="127.0.0.1",
+                        help="Robot IP address. On robot or Local Naoqi: use '127.0.0.1'.")
+    parser.add_argument("--port", type=int, default=9559,
+                        help="Naoqi port number")
+    
+    args = parser.parse_args()
+    session = qi.Session()
+    try:
+        session.connect("tcp://" + args.ip + ":" + str(args.port))
+    except RuntimeError:
+        print ("Can't connect to Naoqi at ip \"" + args.ip + "\" on port " + str(args.port) +".\n"
+               "Please check your script arguments. Run with -h option for help.")
+        sys.exit(1)
+    main(session)

--- a/facial_expression/miraikan_demo/scripts/wakeup.py
+++ b/facial_expression/miraikan_demo/scripts/wakeup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import qi
+import argparse
+import sys
+
+def main(session):
+
+    mo = session.service("ALMotion")
+    mo.wakeUp()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ip", type=str, default="127.0.0.1",
+                        help="Robot IP address. On robot or Local Naoqi: use '127.0.0.1'.")
+    parser.add_argument("--port", type=int, default=9559,
+                        help="Naoqi port number")
+    
+    args = parser.parse_args()
+    session = qi.Session()
+    try:
+        session.connect("tcp://" + args.ip + ":" + str(args.port))
+    except RuntimeError:
+        print ("Can't connect to Naoqi at ip \"" + args.ip + "\" on port " + str(args.port) +".\n"
+               "Please check your script arguments. Run with -h option for help.")
+        sys.exit(1)
+    main(session)


### PR DESCRIPTION
昨日の変更っぽいものと

電源オフ，電源オンだけできる簡単プログラムを追加しました．
```
kanae@kanae-ThinkPad-T480s:~/miraikan_ws/src/Deco_with_robot/facial_expression/miraikan_demo/scripts$ python rest.py --ip 192.168.97.163
[W] 1660013518.637813 7453 qi.path.sdklayout: No Application was created, trying to deduce paths
```

```
kanae@kanae-ThinkPad-T480s:~/miraikan_ws/src/Deco_with_robot/facial_expression/miraikan_demo/scripts$ python wakeup.py --ip 192.168.97.163
[W] 1660013528.037755 7459 qi.path.sdklayout: No Application was created, trying to deduce paths

```